### PR TITLE
fix: correct package module and types entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
     ]
   },
   "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
   "typesVersions": {
     "*": {
       "*": [


### PR DESCRIPTION
## Summary

- Point the package-level `module` field at the published ESM entry (`./dist/index.mjs`).
- Point the package-level `types` field at the published declaration entry (`./dist/index.d.mts`).

## Why

The published `unplugin-oxlint@0.8.0` tarball does not contain the current `./dist/index.js` or `./dist/index.d.ts` paths. Its `exports["." ]` entry already points to the existing `./dist/index.mjs` and `./dist/index.d.mts` files, so this keeps the legacy package fields consistent with the exported root entry.

## Validation

- `node -e "const p=require('./package.json'); if(p.module!=='./dist/index.mjs'||p.types!=='./dist/index.d.mts') process.exit(1); console.log('manifest entries ok')"`
- `git diff --check`
- Verified the npm tarball evidence for `unplugin-oxlint@0.8.0`:
  - current `module: ./dist/index.js` exists: false
  - current `types: ./dist/index.d.ts` exists: false
  - proposed `module: ./dist/index.mjs` exists: true
  - proposed `types: ./dist/index.d.mts` exists: true

I also tried `pnpm install --frozen-lockfile`, but it exceeded the local 180s timeout in this Windows environment before build/test dependencies finished installing.